### PR TITLE
Add logging file path to application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   application:
     name: OngPatinhas
+  logging:
+    file:
+      path: /var/log/springboot
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
This pull request introduces a configuration change to the Spring Boot application by specifying a custom logging file path in `application.yml`. This will direct application logs to a specific directory, which can help with log management and monitoring.

* Logging configuration: Added a `logging.file.path` property to the Spring Boot configuration in `application.yml`, setting the log output directory to `/var/log/springboot`.