### PR TITLE
Update logging file path in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     name: OngPatinhas
   logging:
     file:
-      path: /var/log/springboot
+      path: /var/log/springboot/spring.log
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
This pull request makes a small configuration update to the logging settings in the Spring Boot application's `application.yml` file. The change specifies the exact log file path for application logs.

* Updated the logging file path from `/var/log/springboot` to `/var/log/springboot/spring.log` in `application.yml` to ensure logs are written to a specific file.