### PR TITLE
Change logging file path to logging file name

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     name: OngPatinhas
   logging:
     file:
-      path: /var/log/springboot/spring.log
+      name: /var/log/springboot/spring.log
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
This pull request makes a minor configuration update to the Spring Boot logging setup in `application.yml`. The change updates the logging file property to use `name` instead of `path` for specifying the log file location.