### PR TITLE
Replace ERROR_FILE appender with FULL_LOG appender

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,18 +1,12 @@
 <configuration>
     <springProperty scope="context" name="LOG_PATH" source="LOG_PATH" />
-    <appender name="ERROR_FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FULL_LOG" class="ch.qos.logback.core.FileAppender">
         <file>${LOG_PATH}</file>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>INFO</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
     </appender>
-
-    <root level="INFO">
-        <appender-ref ref="ERROR_FILE" />
+    <root level="DEBUG">
+        <appender-ref ref="FULL_LOG" />
     </root>
 </configuration>


### PR DESCRIPTION
This pull request updates the logging configuration to provide more comprehensive log output and simplifies the log appender setup.

Logging configuration improvements:

* Renamed the `ERROR_FILE` appender to `FULL_LOG` and removed the level filter, allowing all log levels to be captured in the log file (`src/main/resources/logback-spring.xml`).
* Changed the root logger level from `INFO` to `DEBUG` to increase logging verbosity and attached the new `FULL_LOG` appender to the root logger (`src/main/resources/logback-spring.xml`).