### PR TITLE
Update database environment variables in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${DATABASE_URL}
+      SPRING_DATASOURCE_USERNAME: ${DATABASE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${DATABASE_PASSWORD}
+    networks:
+      - backend
+
+  db:
+    image: mysql:8.0
+    container_name: mysql_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DATABASE_PASSWORD}
+      MYSQL_DATABASE: ${DATABASE_URL}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - backend


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` configuration to the project, enabling easy local development and deployment using Docker. The most important changes are the addition of service definitions for the application and database, along with environment variable integration and network configuration.

Docker Compose setup:

* Added a new `app` service that builds from the local `Dockerfile`, exposes port 8080, and sets up environment variables for connecting to the database.
* Added a `db` service using the official MySQL 8.0 image, with persistent storage via Docker volumes and environment variables for database setup.
* Configured both services to use a shared custom network named `backend` to facilitate communication between the application and database containers.