### PR TITLE
Update log volume path in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -112,7 +112,7 @@ jobs:
                   - .env
                 restart: on-failure:3
                 volumes:
-                  - ${{ secrets.LOG_PATH }}:/var/log/springboot
+                  - /home/ong-patinhas/app/logs/:/var/log/springboot
                 depends_on:
                   - db
                 networks:


### PR DESCRIPTION
This pull request updates the log volume path configuration for the Spring Boot service in the CI/CD workflow. The log directory is now explicitly set to a local path instead of using a secret.

* CI/CD workflow configuration:
  * [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L115-R115): Changed the log volume mount for the Spring Boot container from the secret-based `${{ secrets.LOG_PATH }}` to the explicit path `/home/ong-patinhas/app/logs/`.