### PR TITLE
Change root log level from DEBUG to INFO

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="FULL_LOG" />
     </root>
 </configuration>


### PR DESCRIPTION
This pull request makes a small configuration change to the logging level in the `logback-spring.xml` file. The root logger level has been changed from `DEBUG` to `INFO`, which will reduce the verbosity of logs in the application.

* Changed root logger level from `DEBUG` to `INFO` in `logback-spring.xml` to limit log output to informational messages and above.