### PR TITLE
Fix docker-compose version and deploy script path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,7 +102,6 @@ jobs:
       
             echo "Atualizando docker-compose.yml..."
             sudo cat > docker-compose.yml << EOF
-            version: '3.8'
             services:
               app:
                 image: ${{ secrets.DOCKERHUB_USERNAME }}/ong-patinhas-app
@@ -140,7 +139,7 @@ jobs:
             EOF
       
             echo "Executando deploy..."
-            sudo ./deploy.sh 
+            sudo /home/ong-patinhas/app/./deploy.sh 
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes minor updates to the CI/CD workflow configuration to improve deployment reliability.

*Deployment script path update:*

* The path to the deployment script in `.github/workflows/ci-cd.yml` was changed from `sudo ./deploy.sh` to `sudo /home/ong-patinhas/app/./deploy.sh` to ensure the correct script location is used during deployment.

*Docker Compose file simplification:*

* The `version: '3.8'` line was removed from the generated `docker-compose.yml`, likely to avoid version conflicts or to use the default Docker Compose version.Updated docker-compose.yml and deploy script path.